### PR TITLE
Feat/shift click options

### DIFF
--- a/src/clipio_editor/scripts/ClickableFactory.js
+++ b/src/clipio_editor/scripts/ClickableFactory.js
@@ -3,14 +3,17 @@ const { clipboard } = require("electron");
 export class ClickableFactory {
   buildOnclickMethod(clickable) {
     // Construct onclick method from clickableBuilder
-    return () => {
+    return (event) => {
       let clipboardContent = clipboard.readText();
 
       clipboardContent = clickable.run(clipboardContent);
 
       clipboard.writeText(clipboardContent);
 
-      window.close();
+      // When shift-clicked, don't close the window
+      if (!event.shiftKey) {
+        window.close();
+      }
     };
   }
 

--- a/testing/ClickableFactory.test.js
+++ b/testing/ClickableFactory.test.js
@@ -40,10 +40,24 @@ describe("ClickableFactory", () => {
     clipboard.readText.mockImplementation(() => "original text");
 
     const onclick = clickableFactory.buildOnclickMethod(clickable);
-    onclick();
+    const mockEvent = { shiftKey: false }; // Add this line
+    onclick(mockEvent); // Update this line
 
     expect(clickable.run).toHaveBeenCalledWith("original text");
     expect(clipboard.writeText).toHaveBeenCalledWith("original text modified");
+  });
+
+  it("buildOnclickMethod does not close the window if event.shiftKey is true", () => {
+    const clickable = {
+      run: jest.fn(),
+    };
+    const onclick = clickableFactory.buildOnclickMethod(clickable);
+
+    const mockEvent = { shiftKey: true };
+    window.close = jest.fn(); // Mock window.close
+    onclick(mockEvent);
+
+    expect(window.close).not.toHaveBeenCalled(); // Assert that window.close was not called
   });
 
   it("buildClickable assigns an onclick method to the clickable", () => {


### PR DESCRIPTION
Added shift-click to allow for multiple clickables.

Example use case:
User wants to convert to uppercase and remove all spaces.