### PR TITLE
FIX:25 settings window closing when closing editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clipio",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Clipio is a tool that allows immediate editing of content clipboard content when copying to the clipboard",
   "main": "./src/index.js",
   "author": "Constantinos Psomadakis",

--- a/src/clipio_editor/scripts/windowHandler.js
+++ b/src/clipio_editor/scripts/windowHandler.js
@@ -1,15 +1,7 @@
 const { ipcRenderer } = require("electron");
 
 function openSettings() {
-  const settings_width = 1280;
-  const settings_height = 720;
-
-  window.open(
-    "../settings/settings.html",
-    "_blank",
-    `width=${settings_width},height=${settings_height},frame=true,autoHideMenuBar=true,nodeIntegration=yes,contextIsolation=false,` +
-      `icon=${__dirname}/../img/clipio.png`
-  );
+  ipcRenderer.send("launch-settings-window");
 }
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/src/main/ipcmain-channels/events/LaunchSettingsWindow.js
+++ b/src/main/ipcmain-channels/events/LaunchSettingsWindow.js
@@ -1,0 +1,32 @@
+const { BrowserWindow } = require("electron");
+const Event = require("./Event");
+
+class LaunchSettingsWindow extends Event {
+  constructor() {
+    super();
+    this.channel = "launch-settings-window";
+    this.listener = (event, args) => {
+      const commonWindowPreferences = {
+        nodeIntegration: true,
+        contextIsolation: false,
+        enableRemoteModule: true,
+      };
+
+      const settingsWindow = new BrowserWindow({
+        width: 800,
+        height: 600,
+        minHeight: 200,
+        minWidth: 800,
+        autoHideMenuBar: false,
+        show: true,
+        webPreferences: {
+          ...commonWindowPreferences,
+        },
+      });
+
+      settingsWindow.loadFile("./src/settings/settings.html");
+    };
+  }
+}
+
+module.exports = LaunchSettingsWindow;

--- a/src/main/ipcmain-channels/ipcMainChannels.js
+++ b/src/main/ipcmain-channels/ipcMainChannels.js
@@ -9,6 +9,7 @@ const Minimize = require("./events/Minimize");
 const Relaunch = require("./events/Relaunch");
 const SetGithubToken = require("./events/SetGithubToken");
 const SetLocalModules = require("./events/SetLocalModules");
+const LaunchSettingsWindow = require("./events/LaunchSettingsWindow");
 
 const { ipcMain } = require("electron");
 
@@ -26,6 +27,7 @@ function loadAll() {
     new Relaunch(),
     new SetGithubToken(),
     new SetLocalModules(),
+    new LaunchSettingsWindow(),
   ];
 
   events.forEach((event) => {


### PR DESCRIPTION
Fixes bug reported in #25 where opening the settings window from the editor and then closing the editor window would cause both pages to close due to window process cascading.